### PR TITLE
Подключение DSP

### DIFF
--- a/documentSymbolProvider.js
+++ b/documentSymbolProvider.js
@@ -1,0 +1,54 @@
+var vscode = require('vscode');
+
+var BSLDocumentSymbolProvider = (function () {
+	function BSLDocumentSymbolProvider() {
+		this.goKindToCodeKind = {
+			"variable" : vscode.SymbolKind.Variable,
+			"function" : vscode.SymbolKind.Function
+		};
+	}
+	BSLDocumentSymbolProvider.prototype.provideDocumentSymbols = function (document, token) {
+		var _this = this;
+		return new Promise(function (resolve, reject) {
+			var symbols = [];
+			var text = document.getText();
+			var KindToCodeKind = {
+				"variable" : /(перем|var)\s+([a-zа-яё_][a-zа-яё_0-9]*)/ig,
+				"function" : /(процедура|функция|procedure|function)\s+([a-zа-яё_][a-zа-яё_0-9]*)\s*\(/ig
+			};
+			var ArrayKind = ["variable", "function"];
+			ArrayKind.forEach(function (Kind) {
+				var valueMatch = KindToCodeKind[Kind];
+				var match = null;
+				while (match = valueMatch.exec(text)) {
+					var word = match[2];
+					var indexWord = text.indexOf(match[0]) + match[0].indexOf(word);
+					var lineWord = 0;
+					var characterWord = indexWord;
+					var endWord = indexWord + word.length;
+					var pos = text.indexOf("\n");
+					while (pos != -1 && pos <= indexWord) {
+						lineWord++;
+						if (pos <= indexWord) {
+							characterWord = indexWord - pos - 1;
+							endWord = characterWord + word.length;
+						}
+						pos = text.indexOf("\n", pos + 2);
+					}
+					var symbolInfo = new vscode.SymbolInformation(word, _this.goKindToCodeKind[Kind], new vscode.Range(new vscode.Position(lineWord, characterWord), new vscode.Position(lineWord, endWord)), undefined);
+					symbols.push(symbolInfo);
+				}
+			})
+
+			try {
+				return resolve(symbols);
+			} catch (e) {
+				reject(e);
+			}
+
+		});
+	};
+	return BSLDocumentSymbolProvider;
+})();
+exports.default = BSLDocumentSymbolProvider;
+//# sourceMappingURL=goOutline.js.map

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 var vscode = require('vscode');
 
-var BSLDocumentSymbolProvider = require('./documentSymbolProvider');
+var providers = require('./providers');
 
 function activate(context) {
     var disposable = vscode.commands.registerCommand('extension.addpipe', function () {
@@ -25,7 +25,7 @@ function activate(context) {
     });
     context.subscriptions.push(disposable);
     
-    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", BSLDocumentSymbolProvider.default());
+    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", new providers.DocumentSymbolProvider());
     context.subscriptions.push(disposable);
 }
 exports.activate = activate;

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 var vscode = require('vscode');
 
-var providers = require('./providers');
+var bslProviders = require('./providers');
 
 function activate(context) {
     var disposable = vscode.commands.registerCommand('extension.addpipe', function () {
@@ -9,6 +9,7 @@ function activate(context) {
             var position = editor.selection.active;
             var textline = editor.document.getText(new vscode.Range(new vscode.Position(0, 0), position));
             var Regex = /(\/\/.*$)|(\/\/.*\r?\n)|("(""|[^"]*)*")|("[^"]*$)|([^"\/]+)/g;
+            var ArrStrings;
             while ((ArrStrings = Regex.exec(textline)) != null) {
                 var stringmatsh = ArrStrings[5];
             }
@@ -25,11 +26,12 @@ function activate(context) {
     });
     context.subscriptions.push(disposable);
     
-    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", new providers.DocumentSymbolProvider());
+    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", new bslProviders.DocumentSymbolProvider());
     context.subscriptions.push(disposable);
     
-    disposable = vscode.languages.registerDefinitionProvider("bsl", new providers.DefinitionProvider());
+    disposable = vscode.languages.registerDefinitionProvider("bsl", new bslProviders.DefinitionProvider());
     context.subscriptions.push(disposable);
 
 }
+
 exports.activate = activate;

--- a/extension.js
+++ b/extension.js
@@ -1,6 +1,6 @@
 var vscode = require('vscode');
 
-var BSLDocumentSymbolProvider = require('documentSymbolProvider');
+var BSLDocumentSymbolProvider = require('./documentSymbolProvider');
 
 function activate(context) {
     var disposable = vscode.commands.registerCommand('extension.addpipe', function () {
@@ -25,7 +25,7 @@ function activate(context) {
     });
     context.subscriptions.push(disposable);
     
-    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", BSLDocumentSymbolProvider);
+    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", BSLDocumentSymbolProvider.default());
     context.subscriptions.push(disposable);
 }
 exports.activate = activate;

--- a/extension.js
+++ b/extension.js
@@ -27,5 +27,9 @@ function activate(context) {
     
     disposable = vscode.languages.registerDocumentSymbolProvider("bsl", new providers.DocumentSymbolProvider());
     context.subscriptions.push(disposable);
+    
+    disposable = vscode.languages.registerDefinitionProvider("bsl", new providers.DefinitionProvider());
+    context.subscriptions.push(disposable);
+
 }
 exports.activate = activate;

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,7 @@
 var vscode = require('vscode');
 
+var BSLDocumentSymbolProvider = require('documentSymbolProvider');
+
 function activate(context) {
     var disposable = vscode.commands.registerCommand('extension.addpipe', function () {
         var editor = vscode.window.activeTextEditor;
@@ -21,6 +23,9 @@ function activate(context) {
             }
         }
     });
+    context.subscriptions.push(disposable);
+    
+    disposable = vscode.languages.registerDocumentSymbolProvider("bsl", BSLDocumentSymbolProvider);
     context.subscriptions.push(disposable);
 }
 exports.activate = activate;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     },
     "main": "./extension",
     "activationEvents": [
-        "onCommand:extension.addpipe"
+        "onLanguage:bsl"
     ],
     "contributes": {
         "languages": [{

--- a/providers.js
+++ b/providers.js
@@ -50,5 +50,6 @@ var BSLDocumentSymbolProvider = (function () {
 	};
 	return BSLDocumentSymbolProvider;
 })();
-exports.default = BSLDocumentSymbolProvider;
+
+exports.DocumentSymbolProvider = BSLDocumentSymbolProvider;
 //# sourceMappingURL=goOutline.js.map

--- a/providers.js
+++ b/providers.js
@@ -51,5 +51,66 @@ var BSLDocumentSymbolProvider = (function () {
 	return BSLDocumentSymbolProvider;
 })();
 
+var BSLDefinitionProvider = (function () {
+	function BSLDefinitionProvider() {}
+	BSLDefinitionProvider.prototype.provideDefinition = function (document, position, token) {
+		var _this = this;
+
+		var line = position.line;
+		var RangeWord = document.getWordRangeAtPosition(position);
+		var currentWord = document.getText(RangeWord);
+		var offset = RangeWord.end.character;
+
+		var typeOf = null;
+		while (typeOf == null) {
+			if (offset == document.lineAt(line).text.length) {
+				line++;
+				offset = 1;
+			} else {
+				offset++;
+			}
+			var lastOne = document.getText(new vscode.Range(new vscode.Position(line, offset - 1), new vscode.Position(line, offset)))
+				if (lastOne != " ") {
+					if (lastOne == "(") {
+						typeOf = "function";
+					} else {
+						typeOf = "variable"
+					}
+				}
+		}
+		var text = document.getText();
+		var RegexVar = new RegExp('(перем|var)\\s+(' + currentWord + ')', 'ig');
+		var RegexMethod = new RegExp('(процедура|функция|procedure|function)\\s+(' + currentWord + ')\\s*\\(', 'ig');
+		var match = null;
+		if (typeOf == "variable") {
+			match = RegexVar.exec(text);
+		} else {
+			match = RegexMethod.exec(text);
+		}
+		if (match) {
+			var word = match[2];
+			var indexWord = text.indexOf(match[0]) + match[0].indexOf(word);
+			var lineWord = 0;
+			var characterWord = indexWord;
+			var endWord = indexWord + word.length;
+			var pos = text.indexOf("\n");
+			while (pos != -1 && pos <= indexWord) {
+				lineWord++;
+				if (pos <= indexWord) {
+					characterWord = indexWord - pos - 1;
+					endWord = characterWord + word.length;
+				}
+				pos = text.indexOf("\n", pos + 2);
+			}
+			return new vscode.Location(document.uri, new vscode.Range(new vscode.Position(lineWord, characterWord), new vscode.Position(lineWord, endWord)));
+		}
+	};
+	return BSLDefinitionProvider;
+})();
+
+Object.defineProperty(exports, "__esModule", {
+	value : true
+});
+
 exports.DocumentSymbolProvider = BSLDocumentSymbolProvider;
-//# sourceMappingURL=goOutline.js.map
+exports.DefinitionProvider = BSLDefinitionProvider;


### PR DESCRIPTION
@bambr1975 Добавил твой провайдер [отсюда](https://github.com/xDrivenDevelopment/1c-syntax/issues/59) в расширение. Подключил через require и registerDocumentSymbolProvider провайдер.

Запустил расширение в режиме отладки, набрал (даже латиницей) пример
```bsl
procedure proc_name(param)
    param = 0;
endprocedure;

proc_name(0);
```

Go to def не заработал, но это ожидаемо, за это отвечает другой провайдер.
Но и `ctrl-shift-O` (и `ctrl-T`) тоже ничего не выдает.

Что я делаю не так?