### PR TITLE
Правильный текст для определения ошибок от 1script

### DIFF
--- a/src/features/tasksTemplate.ts
+++ b/src/features/tasksTemplate.ts
@@ -54,7 +54,7 @@ export function getTasksObject(): any {
         "problemMatcher": {
           "fileLocation": "absolute",
           "pattern": {
-            "regexp": "^{Модуль\\s+(.*)\\s\\/\\s.*:\\s+(\\d+)\\s+\\/\\s+(.*)}$",
+            "regexp": "{Модуль\\s+(.+)\\s\\/\\s.*:\\s+(\\d+)\\s+\\/\\s+([^{]*)",
             "file": 1,
             "location": 2,
             "message": 3


### PR DESCRIPTION
@nixel2007 Все-таки для vsc также неправильный текст определения ошибок.
Я проверил, у меня теперь точно ловит всякие разные ошибки
Даже вложенные
`{Модуль c:\projects\oscript-library\tests\testrunner.os / Ошибка в строке: 339 / Внешнее исключение: {Модуль c:\projects\1bdd\features\core\step_definitions\БезПараметров.os / Ошибка в строке: 6 / Некорректный символ}`

Fix https://github.com/xDrivenDevelopment/1c-syntax/issues/248